### PR TITLE
Allow optional fields

### DIFF
--- a/lib/tz_datetime.ex
+++ b/lib/tz_datetime.ex
@@ -87,7 +87,7 @@ defmodule TzDatetime do
     input_datetime = get_field(changeset, fields.input_datetime)
     time_zone = get_field(changeset, fields.time_zone)
 
-    case DateTime.from_naive(input_datetime, time_zone) do
+    case safe_from_naive(input_datetime, time_zone) do
       {:ok, correct_datetime} ->
         apply_datetime(changeset, correct_datetime, fields)
 
@@ -124,8 +124,18 @@ defmodule TzDatetime do
 
       {:error, :time_zone_not_found} ->
         add_error(changeset, fields.time_zone, "is invalid")
+
+      nil ->
+        changeset
     end
   end
+
+  # Safely allow nil values when casting to DateTime
+  defp safe_from_naive(nil, _time_zone), do: nil
+  defp safe_from_naive(_input_datetime, nil), do: nil
+
+  defp safe_from_naive(input_datetime, time_zone),
+    do: DateTime.from_naive(input_datetime, time_zone)
 
   # Handle both return options of an edited changeset or a datetime to use
   @spec handle_callback_result(Ecto.Changeset.t(), Ecto.Changeset.t(), fields) ::

--- a/test/support/optional_input_schema.ex
+++ b/test/support/optional_input_schema.ex
@@ -1,0 +1,21 @@
+defmodule TzDatetime.OptionalInputSchema do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  embedded_schema do
+    # Casted datetime
+    field :input_datetime, :naive_datetime, virtual: true
+
+    # Actually stored datetime
+    field :datetime, :utc_datetime
+
+    field :time_zone, :string
+    field :original_offset, :integer
+  end
+
+  def changeset(schema, params) do
+    schema
+    |> cast(params, [:input_datetime, :time_zone])
+  end
+end

--- a/test/tz_datetime_test.exs
+++ b/test/tz_datetime_test.exs
@@ -126,10 +126,10 @@ defmodule TzDatetimeTest do
         :time_zone_periods_from_wall_datetime,
         fn _, "TzDatetime/Test" ->
           period = %{
-          :utc_offset => 3600,
-          :std_offset => 0,
-          :zone_abbr => "TZT"
-        }
+            :utc_offset => 3600,
+            :std_offset => 0,
+            :zone_abbr => "TZT"
+          }
 
           {:ok, period}
         end
@@ -140,7 +140,8 @@ defmodule TzDatetimeTest do
         time_zone: "TzDatetime/Test"
       }
 
-      changeset = TzDatetime.OptionalInputSchema.changeset(%TzDatetime.OptionalInputSchema{}, params)
+      changeset =
+        TzDatetime.OptionalInputSchema.changeset(%TzDatetime.OptionalInputSchema{}, params)
 
       changeset = TzDatetime.handle_datetime(changeset)
       assert {:ok, data} = Ecto.Changeset.apply_action(changeset, :insert)

--- a/test/tz_datetime_test.exs
+++ b/test/tz_datetime_test.exs
@@ -119,6 +119,37 @@ defmodule TzDatetimeTest do
 
       Mox.verify!()
     end
+
+    test "nil input_datetime" do
+      Mox.stub(
+        TzDatetime.TimeZoneDatabaseMock,
+        :time_zone_periods_from_wall_datetime,
+        fn _, "TzDatetime/Test" ->
+          period = %{
+          :utc_offset => 3600,
+          :std_offset => 0,
+          :zone_abbr => "TZT"
+        }
+
+          {:ok, period}
+        end
+      )
+
+      params = %{
+        input_datetime: nil,
+        time_zone: "TzDatetime/Test"
+      }
+
+      changeset = TzDatetime.OptionalInputSchema.changeset(%TzDatetime.OptionalInputSchema{}, params)
+
+      changeset = TzDatetime.handle_datetime(changeset)
+      assert {:ok, data} = Ecto.Changeset.apply_action(changeset, :insert)
+
+      assert data.input_datetime == nil
+      assert data.datetime == nil
+      assert data.time_zone == "TzDatetime/Test"
+      assert data.original_offset == nil
+    end
   end
 
   describe "original_datetime/2" do


### PR DESCRIPTION
I have a schema with a nullable datetime field.
I noticed when testing that if I pass a time_zone but don't pass a date_time that I get a runtime error.
I tested for this and fixed it.